### PR TITLE
Bootstrap reusable Jekyll theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Anodyne Technologies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# anodyne-pages
+# Anodyne Pages
+
+Anodyne Pages is a shared Jekyll documentation theme. It bundles layouts, includes, styles, and scripts that can be reused across multiple product docs sites.
+
+This repository is **not** a GitHub Pages site. It only provides the common theme assets.
+
+## Usage
+
+### Remote theme (public)
+
+Add the [jekyll-remote-theme](https://github.com/benbalter/jekyll-remote-theme) plugin and reference this repository:
+
+```yml
+# in your site's _config.yml
+remote_theme: Anodyne-Technologies/anodyne-pages@v0.1.0
+```
+
+### Git submodule (private)
+
+```
+git submodule add https://github.com/Anodyne-Technologies/anodyne-pages.git theme
+```
+
+Then point `theme` in your site's configuration to the submodule path.
+
+## Customization
+
+- Navigation: provide your own `_data/nav.yml` to override the default links.
+- Brand color: set `brand_color` in your site's `_config.yml` to update the CSS variable `--brand-color`.
+
+## Versioning
+
+Pin to a git tag when consuming this theme. Releases follow semantic versioning. Example: `v0.1.0`.
+
+## License
+
+MIT

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,10 @@
+title: Anodyne Pages
+description: Shared Jekyll theme for Anodyne docs
+brand_color: "#0066cc"
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - LICENSE
+  - node_modules
+  - vendor

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,0 +1,4 @@
+- title: Home
+  url: /
+- title: API
+  url: /api/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,3 @@
+<footer class="footer">
+  <p>&copy; {{ site.time | date: '%Y' }} {{ site.title | default: 'Anodyne' }}</p>
+</footer>

--- a/_includes/sidebar-api.html
+++ b/_includes/sidebar-api.html
@@ -1,0 +1,8 @@
+<aside class="sidebar" id="sidebar">
+  <button class="sidebar-toggle" data-toggle="sidebar" aria-expanded="false">Menu</button>
+  <nav class="sidebar-nav" aria-label="API navigation">
+    {% for item in site.data.nav %}
+    <a href="{{ item.url | relative_url }}">{{ item.title }}</a>
+    {% endfor %}
+  </nav>
+</aside>

--- a/_includes/skiplink.html
+++ b/_includes/skiplink.html
@@ -1,0 +1,1 @@
+<a class="skip-link" href="#content">Skip to content</a>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -1,0 +1,8 @@
+<nav class="topnav" aria-label="Primary">
+  <a class="brand" href="{{ '/' | relative_url }}">{{ site.title | default: 'Docs' }}</a>
+  <ul class="nav-links">
+    {% for item in site.data.nav %}
+    <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
+    {% endfor %}
+  </ul>
+</nav>

--- a/_layouts/api_index.html
+++ b/_layouts/api_index.html
@@ -1,0 +1,9 @@
+---
+layout: default
+---
+<div class="api-layout">
+  {% include sidebar-api.html %}
+  <div class="api-content">
+    {{ content }}
+  </div>
+</div>

--- a/_layouts/api_type.html
+++ b/_layouts/api_type.html
@@ -1,0 +1,6 @@
+---
+layout: api_index
+---
+<article class="api-type">
+  {{ content }}
+</article>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,21 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title | default: site.title }}</title>
+    <link rel="stylesheet" href="{{ '/assets/css/api.css' | relative_url }}">
+  </head>
+  <body>
+    {% include skiplink.html %}
+    {% include topnav.html %}
+    <main id="content">
+      {{ content }}
+    </main>
+    {% include footer.html %}
+    <script src="{{ '/assets/js/toggle.js' | relative_url }}"></script>
+    <script src="{{ '/assets/js/search.js' | relative_url }}"></script>
+  </body>
+</html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+<section class="home">
+  {{ content }}
+</section>

--- a/assets/css/api.css
+++ b/assets/css/api.css
@@ -1,0 +1,56 @@
+---
+---
+:root {
+  --brand-color: {{ site.brand_color | default: '#0066cc' }};
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  line-height: 1.5;
+}
+
+.topnav {
+  background: var(--brand-color);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+}
+
+.topnav a {
+  color: inherit;
+  text-decoration: none;
+  margin-right: 1rem;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 0;
+  width: auto;
+  height: auto;
+  overflow: auto;
+  background: #fff;
+  padding: 1rem;
+}
+
+.sidebar {
+  width: 15rem;
+}
+
+.sidebar.open {
+  display: block;
+}
+
+.sidebar-toggle {
+  background: none;
+  border: none;
+}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,11 @@
+(function () {
+  const input = document.querySelector('input[type="search"]');
+  if (!input) return;
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === '/' && document.activeElement !== input) {
+      e.preventDefault();
+      input.focus();
+    }
+  });
+})();

--- a/assets/js/toggle.js
+++ b/assets/js/toggle.js
@@ -1,0 +1,16 @@
+(function () {
+  const toggle = document.querySelector('[data-toggle="sidebar"]');
+  const sidebar = document.getElementById('sidebar');
+  if (!toggle || !sidebar) return;
+
+  const key = 'anodyne-sidebar';
+  if (localStorage.getItem(key) === 'open') {
+    sidebar.classList.add('open');
+  }
+
+  toggle.addEventListener('click', function () {
+    sidebar.classList.toggle('open');
+    const state = sidebar.classList.contains('open') ? 'open' : 'closed';
+    localStorage.setItem(key, state);
+  });
+})();


### PR DESCRIPTION
## Summary
- scaffold shared Jekyll layouts and includes for docs and API pages
- add accessible navigation, sidebar, and brand color CSS variables
- provide CSS/JS assets plus config and nav data for easy customization

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a10f557250832eb5be638a61c4acc3